### PR TITLE
Convert mailbox name from UTF7-IMAP to RCUBE_CHARSET

### DIFF
--- a/html5_notifier.php
+++ b/html5_notifier.php
@@ -57,7 +57,7 @@ class html5_notifier extends rcube_plugin
 				case 1: $mbox = array_pop(explode('.', str_replace('INBOX.', '', $args['mailbox']))); break;
 				case 2: $mbox = str_replace('.', '/', str_replace('INBOX.', '', $args['mailbox'])); break;
 			}
-			$subject = ((!empty($mbox)) ? $mbox.': ' : '').$msg->get('subject');
+			$subject = ((!empty($mbox)) ? rcube_charset::convert($mbox, 'UTF7-IMAP') . ': ' : '') . $msg->get('subject');
 
             if(strtolower($_SESSION['username']) == strtolower($RCMAIL->user->data['username']) && !in_array($mbox, $excluded_directories))
             {


### PR DESCRIPTION
If the mailbox name contains special characters the name will be converted to UTF7-IMAP charset. If we want to display it with the original characters we have to convert it to RCUBE_CHARSET.