### PR TITLE
Fixes #22 PHP Parse error: syntax error, unexpected end of file in plugins/html5_notifier/config/config.inc.php

### DIFF
--- a/config/config.inc.php.dist
+++ b/config/config.inc.php.dist
@@ -10,4 +10,4 @@ $config['html5_notifier_duration'] = '3';
 $config['html5_notifier_smbox'] = '1'; 
 
 // Directories excluded for notifications. Use ; as separator for multiple directories
-$config['html5_notifier_excluded_directories'] = 'Trash' 
+$config['html5_notifier_excluded_directories'] = 'Trash';


### PR DESCRIPTION
Fixed #22 Missing semicolon in config.inc.php.dist