### PR TITLE
Include version number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "keywords": ["notification","desktop","mail"],
     "homepage": "https://github.com/kitist/html5_notifier",
     "license": "GPL-3.0+",
+    "version": "0.6.4",
     "authors": [
         {
             "name": "Tilman Stremlau",


### PR DESCRIPTION
It's useful to be able to click the about link and see what version the plugin is on, helps knowing if an update is in order.